### PR TITLE
Hotfix 2.7.5

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ url: "https://sharly-chess.com" # the base hostname & protocol for your site, e.
 favicon_ico: "/assets/images/sharly-chess.ico"
 
 doc_version: 2.7
-latest_version: 2.7.4
+latest_version: 2.7.5
 github_url: "https://github.com/sharly-chess/sharly-chess"
 
 # Build settings

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -12,6 +12,7 @@ separator: true
 ## Version 2.7.5 - June 4, 2025
 - Update players when rating types differ in data sources
 - Request the FFE SQL server when augmenting players created from the FIDE database
+- Correction des couleurs du modal de mise à jour des joueur·euses
 
 ## Version 2.7.4 - June 3, 2025
 - Fixed FFE auth test on the tournament editing form

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -9,10 +9,12 @@ separator: true
 
 # Changelog
 
-## Version 2.7.5 - June 5, 2025
+## Version 2.7.5 - June 6, 2025
 - Update players when rating types differ in data sources
 - Request the FFE SQL server when augmenting players created from the FIDE database
 - Fixed the colors of the players update modal
+- Fixed entering results with keyboard shortcuts on fixed boards
+- Removed pairing settings modal when not accurate
 
 ## Version 2.7.4 - June 3, 2025
 - Fixed FFE auth test on the tournament editing form

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -11,6 +11,7 @@ separator: true
 
 ## Version 2.7.5 - June 4, 2025
 - Update players when rating types differ in data sources
+- Request the FFE SQL server when augmenting players created from the FIDE database
 
 ## Version 2.7.4 - June 3, 2025
 - Fixed FFE auth test on the tournament editing form

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -9,6 +9,9 @@ separator: true
 
 # Changelog
 
+## Version 2.7.5 - June 4, 2025
+- Update players when rating types differ in data sources
+
 ## Version 2.7.4 - June 3, 2025
 - Fixed FFE auth test on the tournament editing form
 - Fixed the ChessEvent players' Estimated/National rating type

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -9,7 +9,7 @@ separator: true
 
 # Changelog
 
-## Version 2.7.5 - June 4, 2025
+## Version 2.7.5 - June 5, 2025
 - Update players when rating types differ in data sources
 - Request the FFE SQL server when augmenting players created from the FIDE database
 - Fixed the colors of the players update modal

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -12,7 +12,7 @@ separator: true
 ## Version 2.7.5 - June 4, 2025
 - Update players when rating types differ in data sources
 - Request the FFE SQL server when augmenting players created from the FIDE database
-- Correction des couleurs du modal de mise à jour des joueur·euses
+- Fixed the colors of the players update modal
 
 ## Version 2.7.4 - June 3, 2025
 - Fixed FFE auth test on the tournament editing form

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -9,6 +9,9 @@ separator: true
 
 # Changelog
 
+## Version 2.7.5 - 4 juin 2025
+- Update players when rating types differ in data sources
+
 ## Version 2.7.4 - 3 juin 2025
 - Correction du test des identifiants FFE lors de l'édition des tournois
 - Correction du type de classement Estimé/National des joueur·euses importé·es depuis ChessEvent

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -9,8 +9,9 @@ separator: true
 
 # Changelog
 
-## Version 2.7.5 - 4 juin 2025
-- Update players when rating types differ in data sources
+## Version 2.7.5 - 5 juin 2025
+- Correction de la mise à jour des classements des joueur·euses depuis la base de joueur·euses FFE
+- Utilisation de la base de données du serveur fédéral lors de la création des joueur·euses à partir de la base FIDE
 
 ## Version 2.7.4 - 3 juin 2025
 - Correction du test des identifiants FFE lors de l'édition des tournois

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -12,7 +12,7 @@ separator: true
 ## Version 2.7.5 - 5 juin 2025
 - Correction de la mise à jour des classements des joueur·euses depuis la base de joueur·euses FFE
 - Utilisation de la base de données du serveur fédéral lors de la création des joueur·euses à partir de la base FIDE
-- Fixed the colors of the players update modal
+- Correction des couleurs du modal de mise à jour des joueur·euses
 
 ## Version 2.7.4 - 3 juin 2025
 - Correction du test des identifiants FFE lors de l'édition des tournois

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -9,10 +9,12 @@ separator: true
 
 # Changelog
 
-## Version 2.7.5 - 5 juin 2025
+## Version 2.7.5 - 6 juin 2025
 - Correction de la mise à jour des classements des joueur·euses depuis la base de joueur·euses FFE
 - Utilisation de la base de données du serveur fédéral lors de la création des joueur·euses à partir de la base FIDE
 - Correction des couleurs du modal de mise à jour des joueur·euses
+- Correction de l'entrée de résultats au clavier sur des échiquiers fixes
+- Suppression du modal de configuration de l'appariement lorsque non opportun
 
 ## Version 2.7.4 - 3 juin 2025
 - Correction du test des identifiants FFE lors de l'édition des tournois

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -12,6 +12,7 @@ separator: true
 ## Version 2.7.5 - 5 juin 2025
 - Correction de la mise à jour des classements des joueur·euses depuis la base de joueur·euses FFE
 - Utilisation de la base de données du serveur fédéral lors de la création des joueur·euses à partir de la base FIDE
+- Fixed the colors of the players update modal
 
 ## Version 2.7.4 - 3 juin 2025
 - Correction du test des identifiants FFE lors de l'édition des tournois


### PR DESCRIPTION
Fifth hotfix of Sharly Chess version 2.7:
- Update players when rating types differ in data sources
- Request the FFE SQL server when augmenting players created from the FIDE database
- Fixed the colors of the players update modal
- Fixed entering results with keyboard shortcuts on fixed boards
- Removed pairing settings modal when not accurate