### PR TITLE
Hotfix 2.7.6

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ url: "https://sharly-chess.com" # the base hostname & protocol for your site, e.
 favicon_ico: "/assets/images/sharly-chess.ico"
 
 doc_version: 2.7
-latest_version: 2.7.5
+latest_version: 2.7.6
 github_url: "https://github.com/sharly-chess/sharly-chess"
 
 # Build settings

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -9,6 +9,10 @@ separator: true
 
 # Changelog
 
+## Version 2.7.6 - June 8, 2025
+- Improved exception handling
+- Fixed a bug on event editing
+
 ## Version 2.7.5 - June 6, 2025
 - Update players when rating types differ in data sources
 - Request the FFE SQL server when augmenting players created from the FIDE database

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -11,7 +11,7 @@ separator: true
 
 ## Version 2.7.6 - 8 juin 2025
 - Amélioration de la gestion des exceptions
-- Correction d'un bug sur l'édition des évènements (2.7.6)
+- Correction d'un bug sur l'édition des évènements
 
 ## Version 2.7.5 - 6 juin 2025
 - Correction de la mise à jour des classements des joueur·euses depuis la base de joueur·euses FFE

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -9,6 +9,10 @@ separator: true
 
 # Changelog
 
+## Version 2.7.6 - 8 juin 2025
+- Amélioration de la gestion des exceptions
+- Correction d'un bug sur l'édition des évènements (2.7.6)
+
 ## Version 2.7.5 - 6 juin 2025
 - Correction de la mise à jour des classements des joueur·euses depuis la base de joueur·euses FFE
 - Utilisation de la base de données du serveur fédéral lors de la création des joueur·euses à partir de la base FIDE


### PR DESCRIPTION
Sixth hotfix of Sharly Chess version 2.7:

- Improved exception handling
- Fixed a bug on event editing