### PR TITLE
Hotfix 2.7.7

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ url: "https://sharly-chess.com" # the base hostname & protocol for your site, e.
 favicon_ico: "/assets/images/sharly-chess.ico"
 
 doc_version: 2.7
-latest_version: 2.7.6
+latest_version: 2.7.7
 github_url: "https://github.com/sharly-chess/sharly-chess"
 
 # Build settings

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -9,6 +9,11 @@ separator: true
 
 # Changelog
 
+## Version 2.7.7 - June, 2025
+- Fixed a bug on player creation
+- Fixed FFE online search
+- Improved exception handling
+
 ## Version 2.7.6 - June 8, 2025
 - Improved exception handling
 - Fixed a bug on event editing

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -13,6 +13,10 @@ separator: true
 - Fixed a bug on player creation
 - Fixed FFE online search
 - Improved exception handling
+- Fixed a bug on player creation
+- Fixed FFE online search
+- Fixed searching FFE players by their FIDE ID
+- Fixed adding FIDE players when not present in the FFE database
 
 ## Version 2.7.6 - June 8, 2025
 - Improved exception handling

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -13,6 +13,10 @@ separator: true
 - Correction d'un bug à la création des joueur·euses
 - Correction de la recherche FFE en ligne
 - Amélioration de la gestion des exceptions
+- Correction d'un bug à la création des joueur·euses
+- Correction de la recherche FFE en ligne
+- Correction de la recherche des joueur·euses FFE par leur identifiant FIDE
+- Correction de l'ajout de joueur·euses FIDE non présent·es dans la base FFE
 
 ## Version 2.7.6 - 8 juin 2025
 - Amélioration de la gestion des exceptions

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -9,6 +9,11 @@ separator: true
 
 # Changelog
 
+## Version 2.7.7 - juin 2025
+- Correction d'un bug à la création des joueur·euses
+- Correction de la recherche FFE en ligne
+- Amélioration de la gestion des exceptions
+
 ## Version 2.7.6 - 8 juin 2025
 - Amélioration de la gestion des exceptions
 - Correction d'un bug sur l'édition des évènements


### PR DESCRIPTION
7th hotfix of Sharly Chess 2.7

- Fixed a bug on player creation
- Fixed FFE online search
- Improved exception handling
- Fixed a bug on player creation
- Fixed FFE online search
- Fixed searching FFE players by their FIDE ID
- Fixed adding FIDE players when not present in the FFE database