### PR TITLE
Hotfix 2.7.9

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ url: "https://sharly-chess.com" # the base hostname & protocol for your site, e.
 favicon_ico: "/assets/images/sharly-chess.ico"
 
 doc_version: 2.7
-latest_version: 2.7.8
+latest_version: 2.7.9
 github_url: "https://github.com/sharly-chess/sharly-chess"
 
 # Build settings

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -9,7 +9,7 @@ separator: true
 
 # Changelog
 
-## Version 2.7.9 - June, 2025
+## Version 2.7.9 - June 18, 2025
 - Fixed the duplication of tournament tie-breaks (2.7.9)
 - Fixed the allocation of byes (2.7.9)
 

--- a/dev/changelog.en.md
+++ b/dev/changelog.en.md
@@ -9,6 +9,10 @@ separator: true
 
 # Changelog
 
+## Version 2.7.9 - June, 2025
+- Fixed the duplication of tournament tie-breaks (2.7.9)
+- Fixed the allocation of byes (2.7.9)
+
 ## Version 2.7.8 - June 16, 2025
 - Fixed the indices of the players databases
 - Fixed the display of the Pairings tab when no tournament

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -9,7 +9,7 @@ separator: true
 
 # Changelog
 
-## Version 2.7.9 - juin 2025
+## Version 2.7.9 - 18 juin 2025
 - Correction de la duplication des tie-breaks des tournois (2.7.9)
 - Correction de l'allocation des points-joker (2.7.9)
 

--- a/dev/changelog.fr.md
+++ b/dev/changelog.fr.md
@@ -9,6 +9,10 @@ separator: true
 
 # Changelog
 
+## Version 2.7.9 - juin 2025
+- Correction de la duplication des tie-breaks des tournois (2.7.9)
+- Correction de l'allocation des points-joker (2.7.9)
+
 ## Version 2.7.8 - 16 juin 2025
 - Correction des index des bases de données des joueur·euses
 - Correction de l'affichage de l'onglet Appariements en l'absence de tournois


### PR DESCRIPTION
9th hotfix of Sharly Chess 2.7

- Fixed the duplication of tournament tie-breaks
- Fixed the allocation of byes
